### PR TITLE
Fix #4

### DIFF
--- a/src/main/scala/SiloRef.scala
+++ b/src/main/scala/SiloRef.scala
@@ -6,20 +6,11 @@ import scala.pickling._
 import Defaults._
 import binary._
 
-import scala.concurrent.{Future, Promise, Await}
+import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
 
 import scala.collection.Traversable
 
-
-/*
-object SiloRef {
-  def apply[T](v: T): SiloRef[T] = {
-    new LocalSilo(v)
-  }
-}
-*/
 
 trait SiloRef[W, T <: Traversable[W]] {
   def apply[V, S <: Traversable[V]](fun: Spore[T, S])
@@ -41,14 +32,6 @@ final case class SiloRefId(value: Int)
 
 // this does not extend SiloRef. Silos and SiloRefs are kept separate.
 class LocalSilo[U, T <: Traversable[U]](private[silt] val value: T) {
-/*
-  def apply[S](fun: T => S): SiloRef[S] = {
-    println(s"LocalSiloRef: value = $value")
-    val res = fun(value)
-    println(s"LocalSiloRef: result of applying function: $res")
-    new LocalSilo(res)
-  }
-*/
 
   def internalApply[A, V, B <: Traversable[V]](fun: A => B): LocalSilo[V, B] = {
     val typedFun = fun.asInstanceOf[T => B]

--- a/src/main/scala/netty/ReadStatus.scala
+++ b/src/main/scala/netty/ReadStatus.scala
@@ -1,0 +1,18 @@
+package silt
+package netty
+
+import scala.concurrent.Promise
+import scala.collection.mutable.ArrayBuffer
+
+
+/** Status of reading a message from a channel.
+ */
+sealed abstract class ReadStatus
+
+// Promise `done` is completed with the entire array composed of all chunks
+final case class ChunkStatus(maxSize: Int,
+                             currentSize: Int,
+                             chunks: ArrayBuffer[Array[Byte]],
+                             done: Promise[Array[Byte]]) extends ReadStatus
+
+final case class PartialStatus(arr: Array[Byte]) extends ReadStatus


### PR DESCRIPTION
Handle the case where the byte array received on a channel is less
than 4 bytes long. In that case, not even the final size of the
complete message is known.
